### PR TITLE
Update pr_ai_gen.gemspec version and executable name

### DIFF
--- a/pr_ai_gen.gemspec
+++ b/pr_ai_gen.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "pr_ai_gen"
-  spec.version       = "0.1.0"
+  spec.version       = "0.1.1"
   spec.authors       = ["Lucas Stoller"]
   spec.email         = ["l.s.stoller@gmail.com"]
   spec.summary       = "A CLI tool to generate pull requests using OpenAI"
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files`.split($/)
   spec.bindir        = "exe"
-  spec.executables   = spec.executables = ['pr-ai-gen']
+  spec.executables   = spec.executables = ['pr_ai_gen']
   spec.require_paths = ["lib"]
 
   spec.add_dependency "git", "~> 1.19.1"


### PR DESCRIPTION
# Default PR Template

## Changes Made

In this iteration, we've implemented a minor but crucial update to the `pr_ai_gen` gem. Here's a detailed breakdown of the modifications:

1. **Version Increment**: The version of the `pr_ai_gen` gemspec has been updated from `0.1.0` to `0.1.1`. This increment signifies a backward-compatible bug fix or an enhancement that does not introduce any breaking changes to the current functionality.

2. **Executable Name Correction**: We addressed a minor inconsistency in the naming of the gem's executable. Previously, the executable was named `pr-ai-gen`, but to maintain naming consistency with the gem name (`pr_ai_gen`), the executable name has been changed to `pr_ai_gen`.

These changes aim to enhance the usability and maintainability of the `pr_ai_gen` gem, ensuring that it adheres to semantic versioning principles and naming conventions for easier usage and integration.

The pull request also entails adjustments in the gemspec file to reflect these updates properly.